### PR TITLE
get rid of excess function; fix double error tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,17 +33,13 @@ class GrcSlack extends Base {
   }
 
   logError (reqChannel, err, ...extra) {
-    const parseError = e => {
-      if (err instanceof Error) return e.stack
-      return e
-    }
-    const error = parseError(err)
-
-    const extraP = (extra.length)
+    const error = err instanceof Error ? err.stack : err
+    const extraP = extra.length
       ? `Extra: ${util.format(...extra.map(el => typeof el === 'object' ? util.inspect(el, { depth: 10 }) : el))}, `
       : ''
-    const message = `${extraP}Error: ${error}`
-    return this.message(reqChannel, message)
+    const errTag = err instanceof Error ? '' : 'Error:'
+
+    return this.message(reqChannel, `${extraP}${errTag} ${error}`)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ class GrcSlack extends Base {
   }
 
   logError (reqChannel, err, ...extra) {
-    const error = err instanceof Error ? err.stack : err
+    const error = err instanceof Object ? util.inspect(err, { depth: 10 }) : err
     const extraP = extra.length
       ? `Extra: ${util.format(...extra.map(el => typeof el === 'object' ? util.inspect(el, { depth: 10 }) : el))}, `
       : ''


### PR DESCRIPTION
if `err` parameter is instance of Error, it will have `Error:` prefix in the `err.stack`, hence we don't need it

```
console.log(new Error('test').stack)
'Error: test\n' +
  '    at REPL6:1:1\n' +
  '    at Script.runInThisContext (node:vm:129:12)\n'
```